### PR TITLE
Replace single quotes with double quotes in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ['rails', 'server', '-b', '0.0.0.0']
+CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
From Docker documentation: 

> Note: The exec form is parsed as a JSON array, which means that you must use double-quotes (“) around words not single-quotes (‘).

ref. https://docs.docker.com/engine/reference/builder/#cmd